### PR TITLE
Explicitly specify the command

### DIFF
--- a/LSP-elixir.sublime-settings
+++ b/LSP-elixir.sublime-settings
@@ -1,4 +1,5 @@
 {
+	"command": ["$server_path"],
 	"languages": [
 		{
 			"languageId": "elixir",


### PR DESCRIPTION
By doing that we don't rely on command being filled in from "can_start"
which doesn't work during troubleshooting and also might give worse
error feedback in some cases.