### PR TITLE
Bump elixir-ls to 0.24.1

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -5,9 +5,9 @@ from LSP.plugin.core.typing import Optional
 
 from .server_zip_resource import ServerZipResource
 
-SERVER_VERSION = "0.23.0"
-SERVER_URL = "https://github.com/elixir-lsp/elixir-ls/releases/download/v0.23.0/elixir-ls-v0.23.0.zip"
-SERVER_SHA256 = "d610b67d1172cf2183709749cfe2f2caf5e640e241bb2eeba3593b4d0fb97ff1"
+SERVER_VERSION = "0.24.1"
+SERVER_URL = "https://github.com/elixir-lsp/elixir-ls/releases/download/v0.24.1/elixir-ls-v0.24.1.zip"
+SERVER_SHA256 = "99595d3fa5bec269057632de8160077e313f10369314b04017cc93c7f80f39a7"
 
 SERVER_EXECUTABLES = ["language_server.sh", "launch.sh"]
 BINARY_PATH = (


### PR DESCRIPTION
Since the [Auto Update Workflow](https://github.com/sublimelsp/LSP-elixir/actions/workflows/auto-update.yml) is currently disabled, I bumped the version using `./scripts/update.py`.